### PR TITLE
Include LICENSE file via MANIFEST.in instead of data_files in setup.py.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
     author_email="fridex.devel@gmail.com",
     license="GPLv3+",
     py_modules=["micropipenv"],
-    data_files=[("", ["LICENSE"])],
     cmdclass={"test": Test},
     entry_points={"console_scripts": ["micropipenv=micropipenv:main"]},
     extras_require={


### PR DESCRIPTION
I've found out that the `data_files` in setup.py is not the best way how to include LICENSE in the sdist tarball.

When I switch back to version 0.1.2, the setuptools includes LICENSE file automatically even it's not specified anywhere. It might be caused by some auto-magic and I might have a newer version of setuptools.

However, I've found out that when the LICENSE is specified in setup.py via `data_files` kwarg, it's not just included in sdist tarball but also installed directly to the root folder of a virtual environment or to /usr if you don't use virtual environment (for example in RPM build process).

```
$ python3 -m venv venv
$ source venv/bin/activate
$ pip install .
Processing /home/lbalhar/Software/micropipenv
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: micropipenv
  Building wheel for micropipenv (PEP 517) ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-ct_smpgc/wheels/cb/1a/e6/7f35c498c3c7e79d08e068aff9b55eff9ce3f1b5db97bb74a2
Successfully built micropipenv
Installing collected packages: micropipenv
Successfully installed micropipenv-0.1.4
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
$ ll venv/
total 52
drwxrwxr-x. 2 lbalhar lbalhar  4096 Mar 13 11:13 bin
drwxrwxr-x. 2 lbalhar lbalhar  4096 Mar 13 11:13 include
drwxrwxr-x. 3 lbalhar lbalhar  4096 Mar 13 11:13 lib
lrwxrwxrwx. 1 lbalhar lbalhar     3 Mar 13 11:13 lib64 -> lib
-rw-rw-r--. 1 lbalhar lbalhar 35149 Mar 13 11:13 LICENSE
-rw-rw-r--. 1 lbalhar lbalhar    69 Mar 13 11:13 pyvenv.cfg
```
So, a better solution here might be to use MANIFEST.in specification which should include LICENSE into sdist tarball and install it automatically only into dist-info folder

```
$ python3 -m venv venv2
$ source venv2/bin/activate
$ pip install .
Processing /home/lbalhar/Software/micropipenv
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: micropipenv
  Building wheel for micropipenv (PEP 517) ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-runfyi3l/wheels/cb/1a/e6/7f35c498c3c7e79d08e068aff9b55eff9ce3f1b5db97bb74a2
Successfully built micropipenv
Installing collected packages: micropipenv
Successfully installed micropipenv-0.1.4
WARNING: You are using pip version 19.1.1, however version 20.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
$ ll venv2/
total 16
drwxrwxr-x. 2 lbalhar lbalhar 4096 Mar 13 11:16 bin
drwxrwxr-x. 2 lbalhar lbalhar 4096 Mar 13 11:15 include
drwxrwxr-x. 3 lbalhar lbalhar 4096 Mar 13 11:15 lib
lrwxrwxrwx. 1 lbalhar lbalhar    3 Mar 13 11:15 lib64 -> lib
-rw-rw-r--. 1 lbalhar lbalhar   69 Mar 13 11:15 pyvenv.cfg
$ find ./ -name LICENSE
./LICENSE
./venv2/lib/python3.7/site-packages/micropipenv-0.1.4.dist-info/LICENSE
./venv2/lib/python3.7/site-packages/setuptools-41.2.0.dist-info/LICENSE
```
See [PyPA sample project](https://github.com/pypa/sampleproject), [python-packaging how to](https://python-packaging.readthedocs.io/en/latest/non-code-files.html#adding-non-code-files) and [PyPA user guide](https://packaging.python.org/guides/distributing-packages-using-setuptools/).

You can also try to just remove data_files and use a newer setuptools. When I use setuptools 41.2.0 (the latest python3-setuptools in Fedora 31) the LICENSE is included in sdist automatically.

## Related Issues and Dependencies

#20 #36 

## This introduces a breaking change

- [ ] Yes
- [X] No
