### PR TITLE
Fix requirements creation when Git version of a package is used

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -731,7 +731,7 @@ def _get_package_entry_str(
         result = "git+{}".format(info["git"])
         if "ref" in info:
             result += "@{}".format(info["ref"])
-        result += "#egg={}".format(package_name)
+        result += "#egg={}\n".format(package_name)
         return result
 
     result = package_name


### PR DESCRIPTION
There is missing a new line character, that is causing wrong requirements.txt
file being generated.

## This introduces a breaking change

- [ ] Yes
- [x] No

