### PR TITLE
Implement tox to test micropipenv with all supported Pythons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,45 +16,6 @@ def get_version():
 
     raise ValueError("No version identifier found")
 
-
-class Test(TestCommand):
-    """Introduce test command to run testsuite using pytest."""
-
-    _IMPLICIT_PYTEST_ARGS = [
-        "--timeout=300",
-        "--mypy",
-        "micropipenv.py",
-        "--capture=no",
-        "--verbose",
-        "-l",
-        "-s",
-        "-vv",
-        "tests/",
-    ]
-
-    user_options = [("pytest-args=", "a", "Arguments to pass into py.test")]
-
-    def initialize_options(self):
-        super().initialize_options()
-        self.pytest_args = None
-
-    def finalize_options(self):
-        super().finalize_options()
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-
-        passed_args = list(self._IMPLICIT_PYTEST_ARGS)
-
-        if self.pytest_args:
-            self.pytest_args = [arg for arg in self.pytest_args.split() if arg]
-            passed_args.extend(self.pytest_args)
-
-        sys.exit(pytest.main(passed_args))
-
-
 setup(
     name="micropipenv",
     version=get_version(),
@@ -66,7 +27,6 @@ setup(
     author_email="fridex.devel@gmail.com",
     license="GPLv3+",
     py_modules=["micropipenv"],
-    cmdclass={"test": Test},
     install_requires=["pip"],
     entry_points={"console_scripts": ["micropipenv=micropipenv:main"]},
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py36,py37,py38,py39
+skipsdist = True
+
+[testenv]
+commands = pytest --timeout=300 --mypy micropipenv.py --capture=no --verbose -l -s -vv tests/
+deps =
+    flexmock
+    importlib-resources
+    pytest
+    pytest-mypy
+    pytest-timeout
+    pytest-venv
+    toml


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes: #43 

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements

I've moved the test settings from `setup.py` to `tox.ini` which enables us to test micropipenv with all supported versions on Python.

On Fedora with all supported Pythons, you can use just `tox` command to run the tests:
```
# tox
…
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)
```

We can also use [fedora-python-tox](https://github.com/fedora-python/fedora-python-tox) container image designed for testing with tox on platforms where not all Pythons are available and in CI pipelines. The source to test can be mounted as a volume inside a container or provided as a HTTPS GIT URL which is cloned into a container.

```
# podman run --rm -it --security-opt label=disable -v $PWD:/src -w /src frenzymadness/fedora-python-tox
…
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)
```

## Description

The reason why I removed the definitions from `setup.py` is to not introduce duplicity of test dependencies and settings and also because it's discouraged in the [tox documentation](https://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command).

Now, if you agree, we can implement this into our existing CI but I'd appreciate some help with this task because I don't know zuul.