### PR TITLE
Do not treat multiple indexes as mirrors

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -89,6 +89,7 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
+    from typing import Generator
     from typing import List
     from typing import MutableMapping
     from typing import Optional
@@ -293,19 +294,28 @@ def install_pipenv(
             entry = to_install.popleft()
             package_name, info, had_error = entry["package_name"], entry["info"], entry["error"]
 
-            with open(tmp_file.name, "w") as f:
-                index_config_str = _get_index_entry_str(sections, info)
-                f.write(index_config_str)
-                package_entry_str = _get_package_entry_str(package_name, info)
-                f.write(package_entry_str)
-
             if "git" in info:
                 _LOGGER.warning("!!! Requirement %s uses a VCS version: %r", package_name, info)
 
-            _LOGGER.info("Installing %r", package_entry_str)
-            called_process = subprocess.run(cmd)
+            package_entry_str = _get_package_entry_str(package_name, info)
+            for index_config_str in _iter_index_entry_str(sections, info):
+                with open(tmp_file.name, "w") as f:
+                    f.write(index_config_str)
+                    f.write(package_entry_str)
 
-            if called_process.returncode != 0:
+                _LOGGER.info("Installing %r", package_entry_str)
+                called_process = subprocess.run(cmd)
+
+                if called_process.returncode == 0:
+                    # Discard any error flag if we have any packages that fail to install.
+                    for item in reversed(to_install):
+                        if item["error"] == 0:
+                            # Fast path - errors are always added to the end of the queue,
+                            # if we find a package without any error we can safely break.
+                            break
+                        item["error"] = 0
+                    break
+            else:
                 if len(to_install) == 0 or (had_error and had_error > len(to_install)):
                     raise PipInstallError(
                         "Failed to install requirements, dependency {!r} could not be installed".format(package_name)
@@ -313,14 +323,7 @@ def install_pipenv(
 
                 _LOGGER.warning("Failed to install %r, will try in next installation round...", package_name)
                 to_install.append({"package_name": package_name, "info": info, "error": had_error + 1})
-            else:
-                # Discard any error flag if we have any packages that fail to install.
-                for item in reversed(to_install):
-                    if item["error"] == 0:
-                        # Fast path - errors are always added to the end of the queue,
-                        # if we find a package without any error we can safely break.
-                        break
-                    item["error"] = 0
+
     finally:
         os.remove(tmp_file.name)
 
@@ -804,10 +807,31 @@ def _get_index_entry_str(sections, package_info=None):  # type: (Dict[str, Any],
 
     if index_name is not None and not result:
         raise RequirementsError(
-            "No index found given the configuration: {} (package info: {})".format(sections, package_info),
+            "No index found given the configuration: {} (package info: {})".format(sections, package_info)
         )
 
     return result
+
+
+def _iter_index_entry_str(
+    sections,
+    package_info
+):  # type: (Dict[str, Any], Optional[Dict[str, Any]]) -> Generator[str, None, None]
+    """Iterate over possible package index configurations for the given package to try all possible installations."""
+    index_name = package_info.get("index") if package_info is not None else None
+
+    if index_name is not None or len(sections.get("sources") or []) <= 1:
+        # No need to iterate over indexes, the package index is set and is just one.
+        res = _get_index_entry_str(sections, package_info)
+        yield from [res]
+        return None
+
+    for source in sections["sources"]:
+        result = "--index-url {}\n".format(source["url"])
+        if not source["verify_ssl"]:
+            result += "--trusted-host {}\n".format(urlparse(source["url"]).netloc)
+
+        yield result
 
 
 def requirements_str(

--- a/micropipenv.py
+++ b/micropipenv.py
@@ -814,8 +814,7 @@ def _get_index_entry_str(sections, package_info=None):  # type: (Dict[str, Any],
 
 
 def _iter_index_entry_str(
-    sections,
-    package_info
+    sections, package_info
 ):  # type: (Dict[str, Any], Optional[Dict[str, Any]]) -> Generator[str, None, None]
     """Iterate over possible package index configurations for the given package to try all possible installations."""
     index_name = package_info.get("index") if package_info is not None else None

--- a/tests/data/install/pipenv_iter_index/Pipfile.lock
+++ b/tests/data/install/pipenv_iter_index/Pipfile.lock
@@ -1,0 +1,31 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "foobar"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "some-non-existing-one",
+                "url": "https://some-nonexisting-index-that-will-never-exist.org/simple",
+                "verify_ssl": true
+            },
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "requests": {
+            "hashes": [
+                "sha256:f10d8fbcc02a58056ab44f79ff9b3f9fe78e410296527885250bbb36d15be8c6"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        }
+    },
+    "develop": {}
+}

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -732,16 +732,17 @@ def test_get_index_entry_str_package_info():
         micropipenv._get_index_entry_str(meta_1, {"index": "unknown"})
 
 
-@pytest.mark.parametrize("sections", [
-    {"sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": True}]},
-    {},
-    {"sources": []},
-])
+@pytest.mark.parametrize(
+    "sections",
+    [{"sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": True}]}, {}, {"sources": []}],
+)
 def test_iter_index_entry_str(sections):
     """Test iterating over index configuration entries."""
     obj = flexmock()
     # Package info is not relevant in this case.
-    flexmock(micropipenv).should_receive("_get_index_entry_str").with_args(sections, package_info={}).and_return(obj).once()
+    flexmock(micropipenv).should_receive("_get_index_entry_str").with_args(sections, package_info={}).and_return(
+        obj
+    ).once()
     result = micropipenv._iter_index_entry_str(sections, {})
     # An iterator is returned.
     assert next(result) == obj

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -308,6 +308,13 @@ def test_install_pipenv_deploy_error_hash(venv):
             micropipenv.install_pipenv(get_pip_path(venv), deploy=True)
 
 
+def test_install_pipenv_iter_index(venv):
+    """Test triggering multiple installations if index is not explicitly set to one."""
+    with cwd(os.path.join(_DATA_DIR, "install", "pipenv_iter_index")):
+        micropipenv.install_pipenv(get_pip_path(venv), deploy=False)
+        assert str(venv.get_version("requests")) == "1.0.0"
+
+
 def test_parse_requirements2pipfile_lock():
     """Test parsing of requirements.txt into their Pipfile.lock representation."""
     work_dir = os.path.join(_DATA_DIR, "parse", "pip-tools")
@@ -723,3 +730,20 @@ def test_get_index_entry_str_package_info():
 
     with pytest.raises(micropipenv.RequirementsError):
         micropipenv._get_index_entry_str(meta_1, {"index": "unknown"})
+
+
+@pytest.mark.parametrize("sections", [
+    {"sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": True}]},
+    {},
+    {"sources": []},
+])
+def test_iter_index_entry_str(sections):
+    """Test iterating over index configuration entries."""
+    obj = flexmock()
+    # Package info is not relevant in this case.
+    flexmock(micropipenv).should_receive("_get_index_entry_str").with_args(sections, package_info={}).and_return(obj).once()
+    result = micropipenv._iter_index_entry_str(sections, {})
+    # An iterator is returned.
+    assert next(result) == obj
+    with pytest.raises(StopIteration):
+        next(result)


### PR DESCRIPTION
With this patch, micropipenv will try to iterate over all indexes configured and will issue pip's installation on top of them. This will help in s2i where I'm encountering errors when different artifacts are available on PyPI and AICoE index - the relative ordering is relevant. If the PyPI index is first in the returned Thoth's recommendation, pip will not check AICoE's one and fails on the hash mismatch.

With this logic, micropipenv will iterate over all the configured sources and will try to satisfy requirements cross-package index wide.

This will also help with https://github.com/thoth-station/bz1816214-example

Testsuite passes:
```
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)

```
## This introduces a breaking change

- [ ] Yes
- [x] No
