### PR TITLE
Use Python as Travis CI language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: python
 sudo: required
 
 services:


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Build configuration is stating "ruby" as a language. As ruby is not a language suitable for this project, let's try to change it to "python". I know it has no real impact as we run docker but "ruby" just irritates me in this case.