### PR TITLE
Extend the list of supported pip versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,23 @@ script:
 # To get the list run `tox -l | sed "s/^/  - env: TOXENV=/"`
 matrix:
   include:
-  - env: TOXENV=py36-pip190
+  - env: TOXENV=py36-pip90
+  - env: TOXENV=py36-pip192
+  - env: TOXENV=py36-pip193
   - env: TOXENV=py36-pip200
   - env: TOXENV=py36-pip201
-  - env: TOXENV=py37-pip190
+  - env: TOXENV=py37-pip90
+  - env: TOXENV=py37-pip192
+  - env: TOXENV=py37-pip193
   - env: TOXENV=py37-pip200
   - env: TOXENV=py37-pip201
-  - env: TOXENV=py38-pip190
+  - env: TOXENV=py38-pip90
+  - env: TOXENV=py38-pip192
+  - env: TOXENV=py38-pip193
   - env: TOXENV=py38-pip200
   - env: TOXENV=py38-pip201
-  - env: TOXENV=py39-pip190
+  - env: TOXENV=py39-pip90
+  - env: TOXENV=py39-pip192
+  - env: TOXENV=py39-pip193
   - env: TOXENV=py39-pip200
   - env: TOXENV=py39-pip201

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -35,7 +35,7 @@ import micropipenv
 _DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.relpath(__file__)), "data"))
 # Version of pip to test micropipenv with
 # the default is the pip wheel bundled in virtualenv package
-PIP_VERSION = os.getenv("PIP_VERSION")
+MICROPIPENV_TEST_PIP_VERSION = os.getenv("MICROPIPENV_TEST_PIP_VERSION")
 
 
 @pytest.fixture(name="venv")
@@ -43,11 +43,11 @@ def venv_with_pip(venv):
     """Fixture for virtual environment with specific version of pip.
 
     Fixture uses the original one from pytest_venv,
-    installs pip if PIP_VERSION is given
+    installs pip if MICROPIPENV_TEST_PIP_VERSION is given
     and overwrites the original fixture name
     """
-    if PIP_VERSION is not None:
-        venv.install(f"pip{PIP_VERSION}")
+    if MICROPIPENV_TEST_PIP_VERSION is not None:
+        venv.install(f"pip{MICROPIPENV_TEST_PIP_VERSION}")
     yield venv
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-pip{190,200,201}
+envlist = py{36,37,38,39}-pip{90,191,192,193,200,201}
 skipsdist = True
 
 [testenv]
@@ -13,6 +13,15 @@ deps =
     pytest-venv
     toml
 setenv =
-    pip190: PIP_VERSION = >=19.0,<20.0
+    # platform-python-pip in RHEL8
+    pip90:  PIP_VERSION = >=9.0,<10.0
+    # Fedora 31
+    pip191: PIP_VERSION = >=19.1,<19.2
+    # older version in Python 3.8 module
+    pip192: PIP_VERSION = >=19.2,<19.3
+    # first version with manylinux2014 support, Python 3.8 module, Fedora 32
+    pip193: PIP_VERSION = >=19.3,<20.0
+    # Fedora rawhide (33)
     pip200: PIP_VERSION = >=20.0,<20.1
+    # Latest release
     pip201: PIP_VERSION = >=20.1,<20.2

--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,14 @@ deps =
     toml
 setenv =
     # platform-python-pip in RHEL8
-    pip90:  PIP_VERSION = >=9.0,<10.0
+    pip90:  MICROPIPENV_TEST_PIP_VERSION = >=9.0,<10.0
     # Fedora 31
-    pip191: PIP_VERSION = >=19.1,<19.2
+    pip191: MICROPIPENV_TEST_PIP_VERSION = >=19.1,<19.2
     # older version in Python 3.8 module
-    pip192: PIP_VERSION = >=19.2,<19.3
+    pip192: MICROPIPENV_TEST_PIP_VERSION = >=19.2,<19.3
     # first version with manylinux2014 support, Python 3.8 module, Fedora 32
-    pip193: PIP_VERSION = >=19.3,<20.0
+    pip193: MICROPIPENV_TEST_PIP_VERSION = >=19.3,<20.0
     # Fedora rawhide (33)
-    pip200: PIP_VERSION = >=20.0,<20.1
+    pip200: MICROPIPENV_TEST_PIP_VERSION = >=20.0,<20.1
     # Latest release
-    pip201: PIP_VERSION = >=20.1,<20.2
+    pip201: MICROPIPENV_TEST_PIP_VERSION = >=20.1,<20.2


### PR DESCRIPTION
This change extends the list of supported versions of pip in our CI. I know it does not make sense to include all available releases of pip there so I included only the ones I consider important from the (RHEL) maintenance point of view and added comments for our future selfs.

Version 9 is important because it's the default in RHEL 8 (platform-python-pip) and micropipenv will need to work flawlessly with this version when we package it to RHEL.
We updated pip from 19.2.3 to 19.3.1 after we released Python 3.8 module so it would be nice to support both versions for some time.

By the way, micropipenv has `install_requires=["pip>=9"]` in its setup.py so any incompatibility uncovered by this change should be fixed rather sooner than later. If we decide to not support some specific version of pip for some reason, we should exclude that version in `install_requires`.

## This introduces a breaking change

- [ ] Yes
- [X] No
