### PR TITLE
Implement conditional test skip based on pip version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# micropipenv
+# Copyright(C) 2020 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# type: ignore
+
+import pytest
+import os
+from tempfile import TemporaryDirectory
+
+from pytest_venv import VirtualEnvironment
+from packaging.version import Version
+
+# Version of pip to test micropipenv with
+# the default is the pip wheel bundled in virtualenv package
+MICROPIPENV_TEST_PIP_VERSION = os.getenv("MICROPIPENV_TEST_PIP_VERSION")
+# pip version used in tests, assigned using pytest_configure
+PIP_VERSION = None
+
+
+def _venv_install_pip(venv):
+    """Install pip into the given virtual environment, considering pip version configuration."""
+    if MICROPIPENV_TEST_PIP_VERSION is not None:
+        if MICROPIPENV_TEST_PIP_VERSION == "latest":
+            # This special value always forces the most recent pip version.
+            venv.install("pip", upgrade=True)
+        else:
+            venv.install(f"pip{MICROPIPENV_TEST_PIP_VERSION}")
+
+
+def pytest_configure(config):
+    """Configure tests before pytest collects tests."""
+    global PIP_VERSION
+
+    with TemporaryDirectory() as tmp_dir:
+        venv = VirtualEnvironment(str(tmp_dir))
+        venv.create()
+        _venv_install_pip(venv)
+        PIP_VERSION = Version(str(venv.get_version("pip")))
+
+
+@pytest.fixture(name="venv")
+def venv_with_pip(venv):
+    """Fixture for virtual environment with specific version of pip.
+
+    Fixture uses the original one from pytest_venv,
+    installs pip if MICROPIPENV_TEST_PIP_VERSION is given
+    and overwrites the original fixture name
+    """
+    _venv_install_pip(venv)
+    yield venv

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -31,31 +31,12 @@ import json
 
 import micropipenv
 
+from conftest import PIP_VERSION
+
 
 _DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.relpath(__file__)), "data"))
-# Version of pip to test micropipenv with
-# the default is the pip wheel bundled in virtualenv package
-MICROPIPENV_TEST_PIP_VERSION = os.getenv("MICROPIPENV_TEST_PIP_VERSION")
 # Implementation of `toml` to test micropipenv with
 MICROPIPENV_TEST_TOML_MODULE = os.getenv("MICROPIPENV_TEST_TOML_MODULE", "toml")
-
-
-@pytest.fixture(name="venv")
-def venv_with_pip(venv):
-    """Fixture for virtual environment with specific version of pip.
-
-    Fixture uses the original one from pytest_venv,
-    installs pip if MICROPIPENV_TEST_PIP_VERSION is given
-    and overwrites the original fixture name
-    """
-    if MICROPIPENV_TEST_PIP_VERSION is not None:
-        if MICROPIPENV_TEST_PIP_VERSION == "latest":
-            # This special value always forces the most recent pip version.
-            venv.install("pip", upgrade=True)
-        else:
-            venv.install(f"pip{MICROPIPENV_TEST_PIP_VERSION}")
-
-    yield venv
 
 
 @contextmanager
@@ -125,6 +106,7 @@ def test_install_pipenv_vcs(venv):
     with cwd(os.path.join(_DATA_DIR, "install", "pipenv_vcs")):
         subprocess.run(cmd, check=True, env={"MICROPIPENV_PIP_BIN": get_pip_path(venv), "MICROPIPENV_DEBUG": "1"})
         assert str(venv.get_version("daiquiri")) == "2.0.0"
+
 
 def test_install_pipenv_file(venv):
     """Test invoking installation using information in Pipfile.lock, a file mode is used."""

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest-mypy
     pytest-timeout
     pytest-venv
+    packaging
     toml: toml
     pytoml: pytoml
 setenv =


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #100 #103 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

One can now skip tests based on pip version. An example using [pytest.mark.skipif](https://docs.pytest.org/en/latest/skipping.html#id1):

```python
@pytest.mark.skipif(PIP_VERSION.release >= (20, 0, 0), reason="Some reasoning")
def test_foo():
    pass
```