### PR TITLE
Test micropipenv against pip from the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
   - env: TOXENV=py36-pip200-toml
   - env: TOXENV=py36-pip201-toml
   - env: TOXENV=py36-piplatest-toml
+  - env: TOXENV=py36-pipgit-toml
   - env: TOXENV=py37-pip90-toml
   - env: TOXENV=py37-pip191-toml
   - env: TOXENV=py37-pip192-toml
@@ -30,6 +31,7 @@ matrix:
   - env: TOXENV=py37-pip200-toml
   - env: TOXENV=py37-pip201-toml
   - env: TOXENV=py37-piplatest-toml
+  - env: TOXENV=py37-pipgit-toml
   - env: TOXENV=py38-pip90-toml
   - env: TOXENV=py38-pip191-toml
   - env: TOXENV=py38-pip192-toml
@@ -37,6 +39,7 @@ matrix:
   - env: TOXENV=py38-pip200-toml
   - env: TOXENV=py38-pip201-toml
   - env: TOXENV=py38-piplatest-toml
+  - env: TOXENV=py38-pipgit-toml
   - env: TOXENV=py39-pip90-toml
   - env: TOXENV=py39-pip191-toml
   - env: TOXENV=py39-pip192-toml
@@ -44,9 +47,13 @@ matrix:
   - env: TOXENV=py39-pip200-toml
   - env: TOXENV=py39-pip201-toml
   - env: TOXENV=py39-piplatest-toml
+  - env: TOXENV=py39-pipgit-toml
   - env: TOXENV=py36-pip90-pytoml
   - env: TOXENV=py36-piplatest-pytoml
+  - env: TOXENV=py36-pipgit-pytoml
   - env: TOXENV=py38-pip90-pytoml
   - env: TOXENV=py38-piplatest-pytoml
+  - env: TOXENV=py38-pipgit-pytoml
   - env: TOXENV=py39-pip90-pytoml
   - env: TOXENV=py39-piplatest-pytoml
+  - env: TOXENV=py39-pipgit-pytoml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,8 @@ def _venv_install_pip(venv):
         if MICROPIPENV_TEST_PIP_VERSION == "latest":
             # This special value always forces the most recent pip version.
             venv.install("pip", upgrade=True)
+        elif MICROPIPENV_TEST_PIP_VERSION == "git":
+            venv.install("git+https://github.com/pypa/pip.git")
         else:
             venv.install(f"pip{MICROPIPENV_TEST_PIP_VERSION}")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-pip{90,191,192,193,200,201,latest}-toml,py{36,38,39}-pip{90,latest}-pytoml
+envlist = py{36,37,38,39}-pip{90,191,192,193,200,201,latest,git}-toml,py{36,38,39}-pip{90,latest,git}-pytoml
 skipsdist = True
 
 [testenv]
@@ -28,6 +28,8 @@ setenv =
     pip201: MICROPIPENV_TEST_PIP_VERSION = >=20.1,<20.2
     # Latest release
     piplatest: MICROPIPENV_TEST_PIP_VERSION = latest
+    # Git master
+    pipgit: MICROPIPENV_TEST_PIP_VERSION = git
     # Two implementations of toml format
     toml: MICROPIPENV_TEST_TOML_MODULE = toml
     pytoml: MICROPIPENV_TEST_TOML_MODULE = pytoml


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/micropipenv/issues/120#issuecomment-682385088

## This introduces a breaking change

- [x] No

## Description

Pip's docs about releases say:

> Because releases are made direct from the master branch, it is essential that master is always in a releasable state. It is acceptable to merge PRs that partially implement a new feature, but only if the partially implemented version is usable in that state (for example, with reduced functionality or disabled by default). In the case where a merged PR is found to need extra work before being released, the release manager always has the option to back out the partial change prior to a release. The PR can then be reworked and resubmitted for the next release.