### PR TITLE
Support Python versions with multiple digits

### DIFF
--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -352,7 +352,7 @@ def test_install_pipenv_deploy_error_python(venv):
     """Test installation error on --deploy set, error because Python version."""
     with cwd(os.path.join(_DATA_DIR, "install", "pipenv_error_python")):
         flexmock(micropipenv).should_receive("_maybe_print_pipfile_lock").once()
-        err_msg = r"Running Python version \d.\d, but Pipfile.lock requires Python version 5.9"
+        err_msg = r"Running Python version \d+.\d+, but Pipfile.lock requires Python version 5.9"
         with pytest.raises(micropipenv.PythonVersionMismatch, match=err_msg):
             micropipenv.install_pipenv(get_pip_path(venv), deploy=True)
 


### PR DESCRIPTION
## Related Issues and Dependencies

Micropipenv fails to test with Python 3.10.

    AssertionError: Regex pattern 'Running Python version \\d.\\d, but Pipfile.lock requires Python version 5.9'
    does not match 'Running Python version 3.10, but Pipfile.lock requires Python version 5.9'.

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

It relaxes a testing regex to support Python 3.10, 10.2 or even 12345.678.

## Description

<!--- Describe your changes in detail -->

There's no more detail.