### PR TITLE
fix: Permission error on Windows

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -354,6 +354,7 @@ def install_pipenv(
                 to_install.append({"package_name": package_name, "info": info, "error": had_error + 1})
 
     finally:
+        tmp_file.close()
         os.remove(tmp_file.name)
 
 


### PR DESCRIPTION


## Related Issues and Dependencies

```
PermissionError: [WinError 32] The process cannot access the file because
                 it is being used by another process:
                 'C:\\Users\\jnrg\\AppData\\Local\\Temp\\requirements_micropipenv-qb069zqt.txt'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

A fix for permission error that occurs on Windows during a micropipenv install


```
[...]
Successfully installed urllib3-1.26.3
Collecting vine==1.3.0
  Using cached vine-1.3.0-py2.py3-none-any.whl (14 kB)
Installing collected packages: vine
Successfully installed vine-1.3.0
Traceback (most recent call last):
  File "C:\Python39\Scripts\my-script.py", line 33, in <module>
    sys.exit(load_entry_point('ms-my', 'console_scripts', 'my')())
  File "C:\Python39\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\Python39\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\Python39\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Python39\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Python39\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\users\jnrg\git\my-script-cli\my-script\my-script.py", line 360, in sync
    my-script_sync(project, force, dev)
  File "c:\users\jnrg\git\my-script-cli\my-script\my-script.py", line 186, in my-script_sync
    venv_sync(project, dev)
  File "c:\users\jnrg\git\my-script-cli\my-script\my-script.py", line 219, in venv_sync
    micropipenv.install(pip_bin=os.path.join(workon_home, project, env_bin_dir, "pip"))
  File "C:\Python39\lib\site-packages\micropipenv.py", line 822, in install
    install_pipenv(pip_bin, deploy=deploy, dev=dev, pip_args=pip_args)
  File "C:\Python39\lib\site-packages\micropipenv.py", line 358, in install_pipenv
    os.remove(tmp_file.name)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\jnrg\\AppData\\Local\\Temp\\requirements_micropipenv-qb069zqt.txt'
PS C:\Users\jnrg\git> 
```

## Description

<!--- Describe your changes in detail -->
Thank you for micropipenv, it has been super reliable for linux and mac deployments, great utility. On Windows though with the same Pipfile/Pipfile.lock as used on mac/linux micropipenv consistently exits with that error when trying to remove the tmp requirements file.

I was able to finish my virtualenv environment's installation once I've explicitly closed the tmp_file, before removal

