### PR TITLE
New flexmock does not support module-level import

### DIFF
--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -23,7 +23,7 @@ import glob
 import sys
 from contextlib import contextmanager
 from contextlib import redirect_stdout
-import flexmock
+from flexmock import flexmock
 import os
 import pytest
 import re


### PR DESCRIPTION
See: https://github.com/flexmock/flexmock/blob/master/CHANGELOG.md#changed

## This introduces a breaking change

- [ ] Yes
- [x] No