### PR TITLE
updating to https routes for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
       - id: trailing-whitespace
@@ -20,7 +20,7 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 5.1.1
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
Related to [github security protocol update](https://github.blog/2021-09-01-improving-git-protocol-security-github/#dropping-insecure-signature-algorithms)

Partially addresses [pre-commit fails due to the URL](https://github.com/thoth-station/thoth-application/issues/2111) in Thoth-station/Thoth-application, but for Thoth-station/micropipenv.