### PR TITLE
New test misses `mark.online` decorator

### DIFF
--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -452,6 +452,7 @@ def test_install_pipenv_iter_index(venv):
         assert str(venv.get_version("requests")) == "2.22.0"
 
 
+@pytest.mark.online
 @pytest.mark.parametrize(
     "directory, filename, method",
     [


### PR DESCRIPTION
The new test added by me misses the `mark.online` decorator. No need to do a new release after this, I can skip the test on RPM level.