### PR TITLE
Fix markers

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -766,8 +766,14 @@ def _poetry2pipfile_lock(
             # If there are no additional markers, we have to have a record
             # that the dependency has to be installed unconditionaly and that
             # we have to skip all other additional markers.
+            # Also, we don't care about "extra" markers which are computed separatedly
+            # and are usually not combined with other markers.
             if dependency_name not in pyproject_poetry_section.get("dependencies", {}):
-                if isinstance(dependency_info, dict) and "markers" in dependency_info:
+                if (
+                    isinstance(dependency_info, dict)
+                    and "markers" in dependency_info
+                    and not dependency_info["markers"].startswith("extra")
+                ):
                     additional_markers[normalize_package_name(dependency_name)].append(dependency_info["markers"])
                 else:
                     additional_markers[normalize_package_name(dependency_name)].append(skip_all_markers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@
 
 import pytest
 import os
+import subprocess
 from tempfile import TemporaryDirectory
 
 try:
@@ -52,6 +53,18 @@ def _venv_install_pip(venv):
         venv.install(f"setuptools{MICROPIPENV_TEST_SETUPTOOLS_VERSION}")
 
 
+def _venv_get_version_or_none(self, package):
+    """Extend the original method from pytest-venv fixture.
+
+    See https://github.com/mmerickel/pytest-venv/issues/3
+    """
+    try:
+        version = self.get_version(package)
+        return version
+    except subprocess.CalledProcessError:
+        return None
+
+
 def pytest_configure(config):
     """Configure tests before pytest collects tests."""
     global PIP_VERSION
@@ -80,6 +93,8 @@ def venv_with_pip():
         return pytest.skip("pytest-venv not installed")
 
     with TemporaryDirectory() as tmp_dir:
+        # Extend the VirtulEnvironment class first
+        VirtualEnvironment.get_version_or_none = _venv_get_version_or_none
         venv = VirtualEnvironment(str(tmp_dir))
         venv.create()
         _venv_install_pip(venv)

--- a/tests/data/install/poetry_markers_extra
+++ b/tests/data/install/poetry_markers_extra
@@ -1,0 +1,1 @@
+../parse/poetry_markers_extra

--- a/tests/data/parse/poetry_markers_extra/Pipfile.lock
+++ b/tests/data/parse/poetry_markers_extra/Pipfile.lock
@@ -1,0 +1,74 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b467e6fa262913043641a2ce9d9e47e94046dde6d467cbcd16aa5b74a590b74d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569",
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "version": "==2021.10.8"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "version": "==4.0.0"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "markers": "(python_version >= \"3\")",
+            "version": "==2.0.12"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "markers": "(python_version >= \"3\")",
+            "version": "==3.3"
+        },
+        "requests": {
+            "extras": [
+                "use_chardet_on_py3"
+            ],
+            "hashes": [
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "version": "==2.27.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+            ],
+            "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+            "version": "==1.26.8"
+        }
+    },
+    "develop": {}
+}

--- a/tests/data/parse/poetry_markers_extra/Pipfile_no_default.lock
+++ b/tests/data/parse/poetry_markers_extra/Pipfile_no_default.lock
@@ -1,0 +1,20 @@
+{
+ "_meta": {
+  "hash": {
+   "sha256": "b467e6fa262913043641a2ce9d9e47e94046dde6d467cbcd16aa5b74a590b74d"
+  },
+  "pipfile-spec": 6,
+  "sources": [
+   {
+    "url": "https://pypi.org/simple",
+    "name": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+    "verify_ssl": true
+   }
+  ],
+  "requires": {
+   "python_version": "3.9"
+  }
+ },
+ "default": {},
+ "develop": {}
+}

--- a/tests/data/parse/poetry_markers_extra/Pipfile_no_dev.lock
+++ b/tests/data/parse/poetry_markers_extra/Pipfile_no_dev.lock
@@ -1,0 +1,74 @@
+{
+ "_meta": {
+  "hash": {
+   "sha256": "b467e6fa262913043641a2ce9d9e47e94046dde6d467cbcd16aa5b74a590b74d"
+  },
+  "pipfile-spec": 6,
+  "sources": [
+   {
+    "url": "https://pypi.org/simple",
+    "name": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706",
+    "verify_ssl": true
+   }
+  ],
+  "requires": {
+   "python_version": "3.9"
+  }
+ },
+ "default": {
+  "certifi": {
+   "version": "==2021.10.8",
+   "hashes": [
+    "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569",
+    "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"
+   ],
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  },
+  "chardet": {
+   "version": "==4.0.0",
+   "hashes": [
+    "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5",
+    "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
+   ],
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  },
+  "charset-normalizer": {
+   "version": "==2.0.12",
+   "hashes": [
+    "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+    "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+   ],
+   "markers": "(python_version >= \"3\")",
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  },
+  "idna": {
+   "version": "==3.3",
+   "hashes": [
+    "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+    "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+   ],
+   "markers": "(python_version >= \"3\")",
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  },
+  "requests": {
+   "version": "==2.27.1",
+   "hashes": [
+    "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
+    "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"
+   ],
+   "extras": [
+    "use_chardet_on_py3"
+   ],
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  },
+  "urllib3": {
+   "version": "==1.26.8",
+   "hashes": [
+    "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+    "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+   ],
+   "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
+  }
+ },
+ "develop": {}
+}

--- a/tests/data/parse/poetry_markers_extra/poetry.lock
+++ b/tests/data/parse/poetry_markers_extra/poetry.lock
@@ -1,0 +1,97 @@
+[[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = {version = ">=3.0.2,<5", optional = true, markers = "extra == \"use_chardet_on_py3\""}
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "urllib3"
+version = "1.26.8"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "3.6"
+content-hash = "b467e6fa262913043641a2ce9d9e47e94046dde6d467cbcd16aa5b74a590b74d"
+
+[metadata.files]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+]

--- a/tests/data/parse/poetry_markers_extra/pyproject.toml
+++ b/tests/data/parse/poetry_markers_extra/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = ""
+version = "0.1.0"
+description = ""
+authors = [""]
+
+[tool.poetry.dependencies]
+python = "3.6"
+requests = {version = "==2.27.1", extras = ["use_chardet_on_py3"]}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/data/parse/poetry_markers_skip/Pipfile.lock
+++ b/tests/data/parse/poetry_markers_skip/Pipfile.lock
@@ -71,7 +71,6 @@
     "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
     "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
    ],
-   "markers": "(extra == \"format\") or (python_version >= \"3\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "importlib-metadata": {
@@ -89,7 +88,6 @@
     "sha256:150f80c5badd02c757da6644852f612f88e8b4bc2f9852dcbf557c8738919686",
     "sha256:5a34b698db1eb79ceac454159d3f7c12a451a91f6334a4f638454327b7a89962"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "jsonref": {
@@ -245,7 +243,6 @@
     "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53",
     "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "simplejson": {
@@ -313,7 +310,6 @@
    "hashes": [
     "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "swagger-spec-validator": {
@@ -347,7 +343,6 @@
     "sha256:b8cd5d865a25c51ff1218f0c90d0c0781fc64312a49b746b320cf50de1648f6e",
     "sha256:76f360636957d1c976db7466bc71dcb713bb95ac8911944dffc55c01cb516de6"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "zipp": {

--- a/tests/data/parse/poetry_markers_skip/Pipfile_no_dev.lock
+++ b/tests/data/parse/poetry_markers_skip/Pipfile_no_dev.lock
@@ -71,7 +71,6 @@
     "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
     "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
    ],
-   "markers": "(extra == \"format\") or (python_version >= \"3\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "importlib-metadata": {
@@ -89,7 +88,6 @@
     "sha256:150f80c5badd02c757da6644852f612f88e8b4bc2f9852dcbf557c8738919686",
     "sha256:5a34b698db1eb79ceac454159d3f7c12a451a91f6334a4f638454327b7a89962"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "jsonref": {
@@ -245,7 +243,6 @@
     "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53",
     "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "simplejson": {
@@ -313,7 +310,6 @@
    "hashes": [
     "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "swagger-spec-validator": {
@@ -347,7 +343,6 @@
     "sha256:b8cd5d865a25c51ff1218f0c90d0c0781fc64312a49b746b320cf50de1648f6e",
     "sha256:76f360636957d1c976db7466bc71dcb713bb95ac8911944dffc55c01cb516de6"
    ],
-   "markers": "(extra == \"format\")",
    "index": "5a06749b2297be54ac5699f6f2761716adc5001a2d5f8b915ab2172922dd5706"
   },
   "zipp": {

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -234,6 +234,23 @@ def test_install_poetry_directory_poetry(venv):
 
 
 @pytest.mark.online
+def test_install_poetry_complex_example(venv):
+    """Test invoking installation using information from a Poetry project. Involves complex dependencies, extras and markers."""
+    cmd = [os.path.join(venv.path, BIN_DIR, "python"), micropipenv.__file__, "install", "--method", "poetry"]
+    venv.install(MICROPIPENV_TEST_TOML_MODULE)
+    work_dir = os.path.join(_DATA_DIR, "install", "poetry_markers_extra")
+    with cwd(work_dir):
+        subprocess.run(cmd, check=True, env=get_updated_env(venv))
+        assert str(venv.get_version("requests")) == "2.27.1"
+        # Dependency defined as requests[use_chardet_on_py3] extra
+        assert venv.get_version_or_none("chardet") is not None
+        # unicodedata2 is provided as charset-normalizer[unicode_backport] but is not specified for installation
+        assert venv.get_version_or_none("unicodedata2") is None
+        # also, requests[socks] or urllib3[socks] should not be installed
+        assert venv.get_version_or_none("PySocks") is None
+
+
+@pytest.mark.online
 def test_install_pipenv_env_vars(venv):
     """Test installation using enviroment variables in source URL."""
     cmd = [os.path.join(venv.path, BIN_DIR, "python"), micropipenv.__file__, "install", "--method", "pipenv"]
@@ -754,6 +771,7 @@ def test_parse_requirements2pipfile_lock_not_locked():
         "poetry",
         "poetry_default_dev_diff",
         "poetry_markers_direct",
+        "poetry_markers_extra",
         "poetry_markers_indirect",
         "poetry_markers_order",
         "poetry_markers_transitive_deps",


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #221 
…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Better handling of markers - extra markers are now skipped.

## Description

For some reason, poetry stores information about extras as markers so for example, if we depend on `celery[azureblockblob]` the extra packages looks like this:
```
[package.dependencies]
azure-common = {version = "1.1.5", optional = true, markers = "extra == \"azureblockblob\""}
azure-storage = {version = "0.36.0", optional = true, markers = "extra == \"azureblockblob\""}
azure-storage-common = {version = "1.1.0", optional = true, markers = "extra == \"azureblockblob\""}
```

The markers are not valid for the installation of independent packages and because we already have our own way how to calculate "extras" from the list of packages and the list of provided extras, we don't need that information.

We also already have a test for this combination of markers but because we haven't tested the installation of the resulting pipfile/requirements file, it did not uncover the problem.