### PR TITLE
Return full pipfile_entry dict instead of cherry-picking values

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -1061,15 +1061,7 @@ def _parse_pipfile_dependency_info(pipfile_entry):  # type: (Union[str, Dict[str
     if isinstance(pipfile_entry, str):
         return {"version": pipfile_entry}
     elif isinstance(pipfile_entry, dict):
-        result = {"version": pipfile_entry["version"]}
-
-        if pipfile_entry.get("extras"):
-            result["extras"] = pipfile_entry["extras"]
-
-        if pipfile_entry.get("markers"):
-            result["markers"] = pipfile_entry["markers"]
-
-        return result
+        return pipfile_entry
 
     raise ValueError("Unknown entry in Pipfile (should be of type dict or a str): {}".format(pipfile_entry))
 

--- a/tests/data/requirements/vcs_ref_editable/requirements_only_direct.txt
+++ b/tests/data/requirements/vcs_ref_editable/requirements_only_direct.txt
@@ -1,0 +1,5 @@
+--index-url https://pypi.org/simple
+#
+# Default dependencies
+#
+--editable git+https://github.com/Rapptz/discord.py@87bc79e6e311da60b024ae61a2a3757e55606aa6#egg=discord-py

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -897,6 +897,7 @@ def test_parse_poetry2pipfile_lock(directory, options, expected_file):
         ("vcs_ref_editable", {"no_hashes": True}, "requirements_no_hashes.txt"),
         ("vcs_ref_editable", {"no_indexes": True}, "requirements_no_indexes.txt"),
         ("vcs_ref_editable", {"no_versions": True}, "requirements_no_versions.txt"),
+        ("vcs_ref_editable", {"only_direct": True}, "requirements_only_direct.txt"),
     ],
 )
 def test_requirements(tmp_path, test, options, expected_file):


### PR DESCRIPTION
## Related Issues and Dependencies
fix #256
…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

If there is an unknown key, we won't use it in the rest of the code.
This way, we gain free support for dependencies using git file, etc.

## Caveat

I'm not completely sure of the full impact of the fix. But I think we only use specific keys in the returned dictionnary. Hence we should not have any problem with unknown ones, because we just won't use them.
But that also means we might accept invalid Pifile.
