### PR TITLE
Define a [tests] extra and use it in tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,9 @@ console_scripts =
 [options.extras_require]
 toml =
     toml;python_version<"3.11"
+tests =
+    flexmock
+    pytest
+    pytest-timeout
+    pytest-venv
+    packaging

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,12 @@ envlist =
     py310-pip{latest,git}-tomli
     py311-pip{192,193,203,213,latest,git}
     mypy
-skipsdist = True
 
 [testenv]
 commands = pytest --timeout=300 micropipenv.py --capture=no --verbose -l -s -vv {posargs} tests/
+extras =
+    tests
 deps =
-    flexmock
-    pytest
-    pytest-timeout
-    pytest-venv
-    packaging
     toml: toml
     pytoml: pytoml
     tomli: tomli


### PR DESCRIPTION
## Related Issues and Dependencies

N/A

## This introduces a breaking change

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This allows the Fedora (ELN) package to drop a dependency on tox.

## Description

<!--- Describe your changes in detail -->
The tox package is unwanted in Fedora ELN. It is pulled in by many packages including micropipenv, that only use it to get the list of dependencies. Adding this extra allows us to bypass tox entirely in the Fedora package.