### PR TITLE
Opt out as reviewers for micropipenv

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,7 @@ approvers:
   - VannTen
   - sesheta
 reviewers:
-  - harshad16
+  - frenzymadness
+  - fridex
+  - VannTen
   - kpostoffice


### PR DESCRIPTION
Opt out as reviewers for micropipenv.

## Description

As my focus has shifted a bit and I haven't been able to provide total support in reviewing micropipenv PRs.
I would like to opt out as a reviewer for now and would continue acting as a contributor going further.

Thank you for team to include me as a reviewer. 