### PR TITLE
added env override for default index URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,7 @@ To set the default Python Package Index to something other than `https://pypi.or
 .. code-block:: console
 
   export MICROPIPENV_DEFAULT_INDEX_URLS=https://pypi.example.com/simple,https://pypi.org/simple
+  micropipenv install
 
 
 ``micropipenv install --deploy``

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ To create a virtual environment to be used by ``micropipenv``:
 
   python3 -m venv venv/ && . venv/bin/activate
 
-To set the default Python Package Index to something other than `https://pypi.org/simple`, set the `MICROPIPENV_DEFAULT_INDEX_URLS` to one or more comma-separated URLs.
+To set the default Python Package Index to something other than ``https://pypi.org/simple``, set the ``MICROPIPENV_DEFAULT_INDEX_URLS`` to one or more comma-separated URLs.
 
   Note: if the package manager file contains a package index URL, it will be used over this value.
 

--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ To create a virtual environment to be used by ``micropipenv``:
 
 To set the default Python Package Index to something other than `https://pypi.org/simple`, set the `MICROPIPENV_DEFAULT_INDEX_URLS` to one or more comma-separated URLs.
 
-> Note: if the package manager file contains a package index URL, it will be used over this value.
+  Note: if the package manager file contains a package index URL, it will be used over this value.
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,14 @@ To create a virtual environment to be used by ``micropipenv``:
 
   python3 -m venv venv/ && . venv/bin/activate
 
+To set the default Python Package Index to something other than `https://pypi.org/simple`, set the `MICROPIPENV_DEFAULT_INDEX_URLS` to one or more comma-separated URLs.
+
+> Note: if the package manager file contains a package index URL, it will be used over this value.
+
+.. code-block:: console
+
+  export MICROPIPENV_DEFAULT_INDEX_URLS=https://pypi.example.com/simple,https://pypi.org/simple
+
 
 ``micropipenv install --deploy``
 ================================

--- a/micropipenv.py
+++ b/micropipenv.py
@@ -80,7 +80,7 @@ except Exception:
     raise
 
 try:
-    from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING, Tuple
 except ImportError:
     TYPE_CHECKING = False
 
@@ -96,7 +96,15 @@ if TYPE_CHECKING:
     from typing import Union
     from pip._internal.req.req_file import ParsedRequirement
 
-_DEFAULT_INDEX_URLS = tuple(os.getenv("MICROPIPENV_DEFAULT_INDEX_URLS", "https://pypi.org/simple").split(","))
+
+def get_index_urls():  # type: () -> tuple[str, ...]
+    value = os.getenv("MICROPIPENV_DEFAULT_INDEX_URLS", "https://pypi.org/simple")
+    if value is None or value == "":
+        value = "https://pypi.org/simple"
+    return tuple([x.strip() for x in value.split(",")])
+
+
+_DEFAULT_INDEX_URLS = get_index_urls()
 _MAX_DIR_TRAVERSAL = 42  # Avoid any symlinks that would loop.
 _PIP_BIN = os.getenv("MICROPIPENV_PIP_BIN", "pip")
 _SUPPORTED_PIP = SpecifierSet(_SUPPORTED_PIP_STR)

--- a/micropipenv.py
+++ b/micropipenv.py
@@ -80,7 +80,7 @@ except Exception:
     raise
 
 try:
-    from typing import TYPE_CHECKING, Tuple
+    from typing import TYPE_CHECKING
 except ImportError:
     TYPE_CHECKING = False
 

--- a/micropipenv.py
+++ b/micropipenv.py
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
     from typing import Union
     from pip._internal.req.req_file import ParsedRequirement
 
-_DEFAULT_INDEX_URLS = ("https://pypi.org/simple",)
+_DEFAULT_INDEX_URLS = tuple(os.getenv("MICROPIPENV_DEFAULT_INDEX_URLS", "https://pypi.org/simple").split(","))
 _MAX_DIR_TRAVERSAL = 42  # Avoid any symlinks that would loop.
 _PIP_BIN = os.getenv("MICROPIPENV_PIP_BIN", "pip")
 _SUPPORTED_PIP = SpecifierSet(_SUPPORTED_PIP_STR)

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -104,20 +104,16 @@ def check_generated_pipfile_lock(pipfile_lock_path, pipfile_lock_path_expected):
     os.remove(pipfile_lock_path)
 
 
-@pytest.mark.online
-def test_get_index_urls():
+@pytest.mark.parametrize("input,expected", [
+    ["https://pypi.org/simple, https://example.org/simple", ("https://pypi.org/simple", "https://example.org/simple")],
+    ["https://example.org/simple", ("https://example.org/simple",)],
+    ["", ("https://pypi.org/simple",)]
+])
+def test_get_index_urls(input, expected):
     """Test index url parsing"""
-    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = "https://pypi.org/simple, https://example.org/simple"
+    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = input
     result = micropipenv.get_index_urls()
-    assert result == ("https://pypi.org/simple", "https://example.org/simple")
-
-    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = "https://example.org/simple"
-    result = micropipenv.get_index_urls()
-    assert result == ("https://example.org/simple",)
-
-    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = ""
-    result = micropipenv.get_index_urls()
-    assert result == ("https://pypi.org/simple",)
+    assert result == expected
 
 
 @pytest.mark.online

--- a/tests/test_micropipenv.py
+++ b/tests/test_micropipenv.py
@@ -105,6 +105,22 @@ def check_generated_pipfile_lock(pipfile_lock_path, pipfile_lock_path_expected):
 
 
 @pytest.mark.online
+def test_get_index_urls():
+    """Test index url parsing"""
+    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = "https://pypi.org/simple, https://example.org/simple"
+    result = micropipenv.get_index_urls()
+    assert result == ("https://pypi.org/simple", "https://example.org/simple")
+
+    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = "https://example.org/simple"
+    result = micropipenv.get_index_urls()
+    assert result == ("https://example.org/simple",)
+
+    os.environ["MICROPIPENV_DEFAULT_INDEX_URLS"] = ""
+    result = micropipenv.get_index_urls()
+    assert result == ("https://pypi.org/simple",)
+
+
+@pytest.mark.online
 def test_install_pipenv(venv):
     """Test invoking installation using information in Pipfile.lock."""
     cmd = [os.path.join(venv.path, BIN_DIR, "python"), micropipenv.__file__, "install", "--method", "pipenv"]


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Updates the `_DEFAULT_INDEX_URLS` so that it can be set from an environment variable rather than being hardcoded.

## Description

Context: I am attempting to use Micropipenv in an environment behind a corporate firewall where I cannot access `pypi.org`. To make things more complex, I need to build the application in two different environments which do not have a consistent Pip registry available, meaning I cannot put the registry URL in the package manager configuration file.

This change adds the `MICROPIPENV_DEFAULT_INDEX_URLS` environment variable which allows a consumer to override the default registry that Micropipenv uses if it cannot find one in the package manager config.

This change is implemented in a way that is not breaking. If the environment variable is not set it will behave identically to how it did before.
