### PR TITLE
run tests every monday to check for a possible new pip release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
     - master
+  schedule:
+    - cron: '0 7 * * 1'
 
 name: Run Tox tests on Linux
 


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

pip is released every 3 months. As micropipenv checks for compatible versions in sources, it might be nice to trigger CI periodically and eventually report if it is behind the current pip version, or, if it needs to be adjusted. To support this, run tests every Monday at 7am UTC.