### PR TITLE
Workflow for automatic update of supported pip

### DIFF
--- a/.github/workflows/update_pip.yml
+++ b/.github/workflows/update_pip.yml
@@ -1,0 +1,23 @@
+name: Check and update supported pip
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  check-pip-update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Run the update script
+        run: |
+          .github/workflows/update_supported_pip.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub token for authentication

--- a/.github/workflows/update_supported_pip.sh
+++ b/.github/workflows/update_supported_pip.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get the latest pip release
+python3 -m venv venv
+./venv/bin/pip install --upgrade pip
+PIP_VERSION=$(./venv/bin/pip --version | awk '{print $2}')
+
+# Replace it in the micropipenv.py
+sed -i "/_SUPPORTED_PIP_STR/s/<=[^\"]*\"/<=$PIP_VERSION\"/" micropipenv.py
+
+# Is there any change to propose?
+if [[ -n $(git status --porcelain --untracked-files=no) ]]; then
+  echo "New pip available"
+
+  # Commit the change
+  git config --global user.email "lbalhar@redhat.com"
+  git config --global user.name "Lumír Balhar"
+  git checkout -b update-pip-$PIP_VERSION
+  git add micropipenv.py
+  git commit -m "Update supported pip to $PIP_VERSION"
+  GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git push origin update-pip-$PIP_VERSION
+
+  # Create a pull request using GitHub CLI
+  gh pr create --title "Update supported pip to $PIP_VERSION" --body "SSIA"
+
+else
+  echo "There is nothing to be done…"
+fi


### PR DESCRIPTION
When I downgraded the supported pip version (we have the latest now) and run the workflow on a push to the feature branch, it was able to open a PR in my fork: https://github.com/frenzymadness/micropipenv/pull/4

I think it should work here as well when run by corn.

Cc: @fridex 