### PR TITLE
When a new version of pip is available, show changes in micropipenv first

### DIFF
--- a/.github/workflows/update_supported_pip.sh
+++ b/.github/workflows/update_supported_pip.sh
@@ -12,6 +12,9 @@ sed -i "/_SUPPORTED_PIP_STR/s/<=[^\"]*\"/<=$PIP_VERSION\"/" micropipenv.py
 if [[ -n $(git status --porcelain --untracked-files=no) ]]; then
   echo "New pip available"
 
+  # Show the diff first
+  git --no-pager diff
+
   # Commit the change
   git config --global user.email "lbalhar@redhat.com"
   git config --global user.name "Lumír Balhar"


### PR DESCRIPTION
Just for debug purposes. It seems that the CI job tries to propose a new version even though we already have the latest here.