### PR TITLE
Fix configuration of type checker

### DIFF
--- a/micropipenv.py
+++ b/micropipenv.py
@@ -49,7 +49,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 _LOGGER = logging.getLogger(__title__)
-_SUPPORTED_PIP_STR = ">=9,<=25.0"  # Respects requirement in setup.py and latest pip to release date.
+_SUPPORTED_PIP_STR = ">=9,<=25.0.1"  # Respects requirement in setup.py and latest pip to release date.
 
 try:
     from pip import __version__ as pip_version

--- a/micropipenv.py
+++ b/micropipenv.py
@@ -45,6 +45,7 @@ from collections import defaultdict, deque, OrderedDict
 from itertools import chain
 from importlib import import_module
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 _LOGGER = logging.getLogger(__title__)
@@ -78,11 +79,6 @@ try:
 except Exception:
     _LOGGER.error("Check your pip version, supported pip versions: %s", _SUPPORTED_PIP_STR)
     raise
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from typing import Any

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.9
 warn_unused_configs = true
 disallow_subclassing_any = true
 disallow_any_generics = true


### PR DESCRIPTION
- typing.TYPE_CHECKING is available since 3.5.2, we support 3.6+ so it should be always importable.
- The latest release of mypy does not support 3.6 anymore. The next important version for us is Python 3.9.
