### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=56.0.0", "wheel"]
+requires = ["setuptools>=56.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Removes unnecessary build dependency.

## Description

- current version of setuptools (70.1+) does not need wheel at all
- older versions of setuptools would fetch wheel when building wheels (but not sdists)

